### PR TITLE
☝️ Avoid capturing rolled back callbacks

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,8 +1,9 @@
 History
 =======
 
-* Made ``captureOnCommitCallbacks()`` a ``classmethod`` so it can be used from
-  within class methods such as ``setUpClass()``, ``setUpTestData()``.
+* Made ``captureOnCommitCallbacks()`` a ``classmethod`` so it can be used from within class methods such as ``setUpClass()``, ``setUpTestData()``.
+* Avoiding capturing callbacks enqueued within rolled back ``atomic()`` blocks.
+  As a side effect of this change, the returned list of callbacks is only populated when the context manager exits.
 * Add Django 3.1 support.
 
 1.0.0 (2020-05-20)

--- a/README.rst
+++ b/README.rst
@@ -41,13 +41,14 @@ API
 ------------------------------------------------------------------
 
 Acts as a context manager that captures ``on_commit`` callbacks for the given database connection.
-It returns the list of captured callback functions, from which you can call them.
+It returns a list that contains, on exit of the context only, the captured callback functions.
+From this list you can make assertions on the callbacks or call them to invoke their side effects, mimicking a commit.
 
 All arguments must be passed as keyword arguments.
 
 ``using`` is the alias of the database connection to capture callbacks for.
 
-``execute`` specifies whether to call all the callbacks automatically as the context manager exits.
+``execute`` specifies whether to call all the callbacks automatically as the context manager exits, if no exception has been raised.
 
 For example, you can test a commit hook that sends an email like so:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ where = src
 [flake8]
 max-line-length = 80
 select = C,E,F,W,B,B950
-ignore = E501,W503
+ignore = E203,E501,W503
 
 [isort]
 include_trailing_comma = True


### PR DESCRIPTION
Fixes #6.