### PR TITLE
Stop including changelog in PyPI description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = django-capture-on-commit-callbacks
 version = 1.1.0
 description = Capture and make assertions on transaction.on_commit() callbacks.
-long_description = file: README.rst, HISTORY.rst
+long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = Adam Johnson
 author_email = me@adamj.eu


### PR DESCRIPTION
It's linked prominently through project_urls already, it doesn't need to pollute the PyPI display of the README. Additionally it's sometimes necessary to push a change for a past release, but such changes cannot be added to that release's PyPI description as it's immutable.