### PR TITLE
Tidy up recursive behaviour

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+* Capture callbacks recursively.
+  This backports the new behaviour from Django 4.0 (`Ticket #33054 <https://code.djangoproject.com/ticket/33054>`__).
+
+  Thanks to Eugene Morozov in `PR #118 <https://github.com/adamchainz/django-capture-on-commit-callbacks/pull/118>`__.
+
 1.6.0 (2021-08-14)
 ------------------
 

--- a/src/django_capture_on_commit_callbacks/__init__.py
+++ b/src/django_capture_on_commit_callbacks/__init__.py
@@ -34,7 +34,7 @@ def capture_on_commit_callbacks(
                 for callback in callbacks:
                     callback()
 
-            if callback_count == len(connections[using].run_on_commit):
+            if len(connections[using].run_on_commit) == callback_count:
                 break
             start_count = callback_count - 1
             callback_count = len(connections[using].run_on_commit)

--- a/tests/test_capture_on_commit_callbacks.py
+++ b/tests/test_capture_on_commit_callbacks.py
@@ -64,13 +64,6 @@ else:
 
     class CaptureOnCommitCallbacksTests(TestCase):  # type: ignore [no-redef]
         databases = ["default", "other"]
-        callback_called = False
-
-        def enqueue_callback(self):
-            def hook():
-                self.callback_called = True
-
-            transaction.on_commit(hook)
 
         def test_with_no_arguments(self):
             with capture_on_commit_callbacks() as callbacks:
@@ -129,11 +122,20 @@ else:
             self.assertEqual(callbacks, [])
 
         def test_execute_recursive(self):
+            callback_called = False
+
+            def enqueue_callback(self):
+                def hook():
+                    nonlocal callback_called
+                    callback_called = True
+
+                transaction.on_commit(hook)
+
             with capture_on_commit_callbacks(execute=True) as callbacks:
-                transaction.on_commit(self.enqueue_callback)
+                transaction.on_commit(enqueue_callback)
 
             self.assertEqual(len(callbacks), 2)
-            self.assertIs(self.callback_called, True)
+            self.assertTrue(callback_called)
 
     class TestCaseMixinTests(TestCaseMixin, TestCase):  # type: ignore [no-redef]
         databases = ["default", "other"]

--- a/tests/test_capture_on_commit_callbacks.py
+++ b/tests/test_capture_on_commit_callbacks.py
@@ -124,7 +124,7 @@ else:
         def test_execute_recursive(self):
             callback_called = False
 
-            def enqueue_callback(self):
+            def enqueue_callback():
                 def hook():
                     nonlocal callback_called
                     callback_called = True


### PR DESCRIPTION
* Add changelog note
* Switch order of comparison to be more natural
* Use an inner function for the test rather than a method that's many lines before