### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - src:tests
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/django_capture_on_commit_callbacks/__init__.py
+++ b/src/django_capture_on_commit_callbacks/__init__.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Any, Callable, ContextManager, Generator
+from typing import Any
+from typing import Callable
+from typing import ContextManager
+from typing import Generator
 
 import django
 from django.core.exceptions import ImproperlyConfigured
-from django.db import DEFAULT_DB_ALIAS, connections
+from django.db import connections
+from django.db import DEFAULT_DB_ALIAS
 
 
 def check_django_version() -> None:

--- a/tests/test_capture_on_commit_callbacks.py
+++ b/tests/test_capture_on_commit_callbacks.py
@@ -9,13 +9,12 @@ from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from django.db.utils import IntegrityError
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase
+from django.test import TestCase
 
-from django_capture_on_commit_callbacks import (
-    TestCaseMixin,
-    capture_on_commit_callbacks,
-    check_django_version,
-)
+from django_capture_on_commit_callbacks import capture_on_commit_callbacks
+from django_capture_on_commit_callbacks import check_django_version
+from django_capture_on_commit_callbacks import TestCaseMixin
 
 mock_django_version = partial(mock.patch.object, django, "VERSION")
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from django.urls import path
-
 from tests import views
 
 urlpatterns = [

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django.core import mail
-from django.db import DEFAULT_DB_ALIAS, transaction
+from django.db import DEFAULT_DB_ALIAS
+from django.db import transaction
 from django.http import HttpResponse
 from django.views.decorators.http import require_POST
 


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
